### PR TITLE
Add premmier league position in the index page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "WebFetch(domain:sports.core.api.espn.com)",
       "Bash(mkdir:*)",
       "Bash(bin/rails console:*)",
-      "Bash(curl:*)"
+      "Bash(curl:*)",
+      "Bash(bin/rails:*)"
     ],
     "deny": []
   }

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -2,8 +2,8 @@ class TeamsController < ApplicationController
   def index
     @teams = EspnApiService.fetch_teams
 
-    # Sort teams by name for now (will change to ranking when we have win/loss data)
-    @teams = @teams.sort_by(&:display_name)
+    # Sort teams by league position (position 1 = first place)
+    @teams = @teams.sort_by { |team| team.position || Float::INFINITY }
   end
 
   def show

--- a/app/models/domain/team.rb
+++ b/app/models/domain/team.rb
@@ -1,6 +1,6 @@
 module Domain
   Team = ImmutableStruct.new(:espn_id, :name, :display_name, :short_name, :nickname,
-                             :location, :color, :alternate_color, :logo_url, :logo_dark_url, :active) do
+                             :location, :color, :alternate_color, :logo_url, :logo_dark_url, :active, :position) do
     # For future ranking - placeholder for now
     def ranking_score
       # TODO: Implement actual ranking based on wins/losses when we get that data

--- a/app/services/espn_api_service.rb
+++ b/app/services/espn_api_service.rb
@@ -14,7 +14,7 @@ class EspnApiService
 
         return [] unless response
         teams_data = response.dig("sports", 0, "leagues", 0, "teams") || []
-        teams_data.map do |team_data|
+        teams_with_standings = teams_data.map do |team_data|
           team_info = team_data["team"]
           ::Domain::Team.new(
             espn_id: team_info["id"],
@@ -27,10 +27,69 @@ class EspnApiService
             alternate_color: team_info["alternateColor"],
             logo_url: team_info.dig("logos", 0, "href"),
             logo_dark_url: team_info.dig("logos", 1, "href"),
-            active: team_info["isActive"]
+            active: team_info["isActive"],
+            position: nil
           )
         end
+
+        add_standings_data(teams_with_standings)
       end
+    end
+
+    def fetch_standings
+      Rails.cache.fetch("espn_standings", expires_in: CACHE_EXPIRY) do
+        generate_mock_standings
+      end
+    end
+
+    private
+
+    def add_standings_data(teams)
+      standings = fetch_standings
+      teams.map do |team|
+        standing = standings.find { |s| s[:espn_id] == team.espn_id }
+        position = standing&.dig(:position)
+
+        ::Domain::Team.new(
+          espn_id: team.espn_id,
+          name: team.name,
+          display_name: team.display_name,
+          short_name: team.short_name,
+          nickname: team.nickname,
+          location: team.location,
+          color: team.color,
+          alternate_color: team.alternate_color,
+          logo_url: team.logo_url,
+          logo_dark_url: team.logo_dark_url,
+          active: team.active,
+          position: position
+        )
+      end
+    end
+
+    def generate_mock_standings
+      [
+        { espn_id: "364", position: 1 },   # Liverpool
+        { espn_id: "359", position: 2 },   # Arsenal
+        { espn_id: "363", position: 3 },   # Chelsea
+        { espn_id: "382", position: 4 },   # Manchester City
+        { espn_id: "361", position: 5 },   # Newcastle
+        { espn_id: "362", position: 6 },   # Aston Villa
+        { espn_id: "393", position: 7 },   # Nottingham Forest
+        { espn_id: "331", position: 8 },   # Brighton
+        { espn_id: "370", position: 9 },   # Fulham
+        { espn_id: "367", position: 10 },  # Tottenham
+        { espn_id: "337", position: 11 },  # Brentford
+        { espn_id: "360", position: 12 },  # Manchester United
+        { espn_id: "371", position: 13 },  # West Ham
+        { espn_id: "384", position: 14 },  # Crystal Palace
+        { espn_id: "349", position: 15 },  # Bournemouth
+        { espn_id: "380", position: 16 },  # Wolves
+        { espn_id: "368", position: 17 },  # Everton
+        { espn_id: "357", position: 18 },  # Leeds
+        { espn_id: "366", position: 19 },  # Sunderland
+        { espn_id: "379", position: 20 }   # Burnley
+      ]
     end
 
     private

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -8,11 +8,11 @@
     <% @teams.each do |team| %>
       <%= link_to team_path(team.espn_id), class: "team-card-link" do %>
         <div class="team-card">
-        <div class="position-badge">
           <% if team.position %>
-            <span class="position-number position-<%= team.position <= 4 ? 'top' : team.position >= 18 ? 'bottom' : 'middle' %>">#<%= team.position %></span>
+            <div class="position-badge">
+              <span class="position-number position-<%= team.position <= 4 ? 'top' : team.position >= 18 ? 'bottom' : 'middle' %>">#<%= team.position %></span>
+            </div>
           <% end %>
-        </div>
         <div class="team-logo">
           <% if team.logo_url %>
             <%= image_tag team.logo_url, alt: "#{team.display_name} logo", class: "logo" %>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -8,6 +8,11 @@
     <% @teams.each do |team| %>
       <%= link_to team_path(team.espn_id), class: "team-card-link" do %>
         <div class="team-card">
+        <div class="position-badge">
+          <% if team.position %>
+            <span class="position-number position-<%= team.position <= 4 ? 'top' : team.position >= 18 ? 'bottom' : 'middle' %>">#<%= team.position %></span>
+          <% end %>
+        </div>
         <div class="team-logo">
           <% if team.logo_url %>
             <%= image_tag team.logo_url, alt: "#{team.display_name} logo", class: "logo" %>
@@ -85,6 +90,35 @@
     padding: 20px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     transition: transform 0.2s;
+    position: relative;
+  }
+
+  .position-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 10;
+  }
+
+  .position-number {
+    color: white;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  }
+
+  .position-top {
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+  }
+
+  .position-middle {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  }
+
+  .position-bottom {
+    background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
   }
   
   .team-card-link {


### PR DESCRIPTION
This pull request introduces functionality to display team rankings based on their league positions, including backend changes to fetch and process standings data and frontend updates to visually represent rankings. The most important changes are grouped into backend enhancements and frontend updates.

### Backend Enhancements:
* **Team Model Update**: Added a `position` attribute to the `Domain::Team` model to store league rankings.
* **Standings Integration**: Updated `EspnApiService.fetch_teams` to include a new `add_standings_data` method, which enriches team data with league positions. Added a `fetch_standings` method with mock data for testing.
* **Sorting by Position**: Modified `TeamsController#index` to sort teams by their league position, with teams lacking a position sorted last.

### Frontend Updates:
* **Position Badge Display**: Updated `app/views/teams/index.html.erb` to display a badge with the team's league position. The badge styling changes dynamically based on the position (top, middle, or bottom).
* **CSS for Position Badges**: Added styles for the position badge, including colors and gradients to visually differentiate top, middle, and bottom-ranked teams.

### Additional Changes:
* **Local Settings Update**: Added `Bash(bin/rails:*)` to the allowlist in `.claude/settings.local.json`.